### PR TITLE
Update M1 Makefile for latest libusb

### DIFF
--- a/xmos_dfu/Makefile
+++ b/xmos_dfu/Makefile
@@ -1,6 +1,6 @@
 mac:
 	g++ -g -o xmosdfu xmosdfu.cpp -I. -IOSX /usr/local/lib/libusb-1.0.0.dylib
 mac-m1:
-	g++ -g -o xmosdfu xmosdfu.cpp -I. -IOSX /opt/homebrew/Cellar/libusb/1.0.25/lib/libusb-1.0.0.dylib
+	g++ -g -o xmosdfu xmosdfu.cpp -I. -IOSX /opt/homebrew/Cellar/libusb/1.0.26/lib/libusb-1.0.0.dylib
 linux:
 	g++ -g -o xmosdfu xmosdfu.cpp `pkg-config --libs --cflags libusb-1.0`


### PR DESCRIPTION
libusb seems to be at 1.0.26, so I needed this change for the M1 make cmd to work