### PR TITLE
the case of the the usb IDs matters

### DIFF
--- a/packaging/linux/70-jdslabs.rules
+++ b/packaging/linux/70-jdslabs.rules
@@ -11,29 +11,29 @@
 #
 
 # ATOMDAC2_PID
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="88E8",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="88E8",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="88e8",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="88e8",  TAG+="uaccess"
 # ATOMDAC_PID
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="30E1",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="30E1",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="30e1",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="30e1",  TAG+="uaccess"
 # EL4_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="88fa",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="88fa",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="88fa",  TAG+="uaccess"
 # EL4_DFU_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="88fc",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="88fc",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="88fc",  TAG+="uaccess"
 # ELEMENTII_PID
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="30DA",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="30DA",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="30da",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="30da",  TAG+="uaccess"
 # ELDACII_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="30E0",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="30E0",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="30E0",  TAG+="uaccess"
 # ELEMENTIII_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="8885",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="8885",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="8885",  TAG+="uaccess"
 # ELDACIIPLUS_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="8886",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="8886",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="8886",  TAG+="uaccess"
 # ELDACIIPLUSBal_PID
 SUBSYSTEM=="usb",    ATTRS{idVendor}=="20b1", ATTRS{idProduct}=="8889",  TAG+="uaccess"
-SUBSYSTEM=="usb",    ATTRS{idVendor}=="152A", ATTRS{idProduct}=="8889",  TAG+="uaccess"
+SUBSYSTEM=="usb",    ATTRS{idVendor}=="152a", ATTRS{idProduct}=="8889",  TAG+="uaccess"


### PR DESCRIPTION
lowercase all the vendor and product IDs

I finally had time to debug why the udev rules did not match. And your linux help gave me the hint.

If you want make the linux help on the core page a bit less dangerous then you can replace the MODE with TAG+="uaccess" there as well.